### PR TITLE
Fix logging handler crash due to hostname resolution error

### DIFF
--- a/pyeslogging/handlers.py
+++ b/pyeslogging/handlers.py
@@ -208,11 +208,14 @@ class PYESHandler(logging.Handler):
         self.index_name_frequency = index_name_frequency
         self.es_doc_type = es_doc_type
         self.es_additional_fields = es_additional_fields.copy()
-        self.es_additional_fields.update({'host': socket.gethostname(),
-                                          'host_ip': socket.gethostbyname(socket.gethostname())})
+        try:
+            self.es_additional_fields.update({'host': socket.gethostname(),
+                                              'host_ip': socket.gethostbyname(socket.gethostname())})
+        except:
+            self.es_additional_fields.update({'host': 'localhost',
+                                              'host_ip': '127.0.0.1'})
         self.raise_on_indexing_exceptions = raise_on_indexing_exceptions
         self.default_timestamp_field_name = default_timestamp_field_name
-
         self._client = None
         self._buffer = []
         self._buffer_lock = Lock()


### PR DESCRIPTION
Added exception handling to prevent crashes caused by hostname resolution failure in the logging handler. If resolution fails, the handler now defaults to localhost (127.0.0.1) for the host IP, ensuring uninterrupted logging functionality.